### PR TITLE
fix(sortBy): default extract if not provided

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -289,7 +289,7 @@ export const unionBy = uniqueBy;
  *
  * @return {Array}
  */
-export function sortBy(collection, extractor) {
+export function sortBy(collection, extractor = (e) => e) {
 
   extractor = toExtractor(extractor);
 


### PR DESCRIPTION
Allow no extractor to be defined which will return the original value.
This is useful when doing sortBy(arrayOfStrings) to sort without defining an extractor function.