### PR TITLE
feat(unique): add unique

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -279,6 +279,7 @@ export function uniqueBy(extractor, ...collections) {
 
 export const unionBy = uniqueBy;
 
+export const unique = uniqueBy.bind(this, (e) => e);
 
 
 /**


### PR DESCRIPTION
unique is like lodash's uniq, it does not take an extractor.
usage: `unique(['b','a','d','c','a','d']);` outputs `["b", "a", "d", "c"]`

This method has a very small footprint, binding to uniqueBy to provide the extractor