### PR TITLE
chore(fn/debounce): work without #clearTimeout

### DIFF
--- a/lib/fn.js
+++ b/lib/fn.js
@@ -1,5 +1,3 @@
-const slice = Array.prototype.slice;
-
 /**
  * Debounce fn, calling it only once if
  * the given time elapsed between calls.
@@ -13,17 +11,41 @@ export function debounce(fn, timeout) {
 
   var timer;
 
-  return function() {
+  var lastArgs;
+  var lastThis;
 
-    var args = slice.call(arguments);
+  var lastNow;
 
-    if (timer) {
-      clearTimeout(timer);
+  function fire() {
+
+    var now = Date.now();
+
+    var scheduledDiff = (lastNow + timeout) - now;
+
+    if (scheduledDiff > 0) {
+      return schedule(scheduledDiff);
     }
 
-    timer = setTimeout(function() {
-      fn(...args);
-    }, timeout);
+    fn.apply(lastThis, lastArgs);
+
+    timer = lastNow = lastArgs = lastThis = undefined;
+  }
+
+  function schedule(timeout) {
+    timer = setTimeout(fire, timeout);
+  }
+
+  return function(...args) {
+
+    lastNow = Date.now();
+
+    lastArgs = args;
+    lastThis = this;
+
+    // ensure an execution is scheduled
+    if (!timer) {
+      schedule(timeout);
+    }
   };
 
 }


### PR DESCRIPTION
Adding many different listeners and clearing them can
be a performance concern.

This PR ensures that only one listener is used to implement
debounce. This makes #clearTimeout unnecessary.

It adds additional test coverage that verifies the debounced fn is
called with last (this, ...args), too.