### PR TITLE
fix(types): make bind return same fn type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,7 +28,7 @@ export function throttle(fn: Function, interval: number): (...args: any[]) => vo
  *
  * @return {Function} bound function
  */
-export function bind(fn: Function, target: object): Function;
+export function bind<T extends Function>(fn: T, target: object): T;
 
 /**
  * Copy the values of all of the enumerable own properties from one or more source objects to a


### PR DESCRIPTION
This prevents TypeScript errors induced via returning a generic Function, e.g.

```
Argument of type 'Function' is not assignable to parameter of type '(x: number) => string'.
  Type 'Function' provides no match for the signature '(x: number): string'.ts(2345)
```

See this CodeSandbox for a test case: https://codesandbox.io/s/20pqkq347n?fontsize=14