### PR TITLE
fix(object#set): enforce key types

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -35,6 +35,14 @@ export function set(target, path, value) {
 
   forEach(path, function(key, idx) {
 
+    if (typeof key !== 'number' && typeof key !== 'string') {
+      throw new Error('illegal key type: ' + typeof key + '. Key should be of type number or string.');
+    }
+
+    if (key === 'constructor') {
+      throw new Error('illegal key: constructor');
+    }
+
     if (key === '__proto__') {
       throw new Error('illegal key: __proto__');
     }

--- a/test/object.spec.js
+++ b/test/object.spec.js
@@ -448,6 +448,27 @@ describe('object', function() {
       }).to.throw(/illegal key/);
     });
 
+
+    it('should not allow prototype polution via constructor', function() {
+      expect(function() {
+        set({}, ['constructor', 'prototype', 'polluted'], 'success');
+      }).to.throw(/illegal key/);
+    });
+
+
+    it('should not allow array as key', function() {
+      expect(function() {
+        set({}, [['__proto__'], 'polluted'], 'success');
+      }).to.throw(/illegal key type/);
+    });
+
+
+    it('should not allow object as key', function() {
+      expect(function() {
+        set({}, [{}, 'polluted'], 'success');
+      }).to.throw(/illegal key type/);
+    });
+
   });
 
 


### PR DESCRIPTION

This also fixes the prototype pollution through `set({}, [["__proto__"], "polluted"], "success")`
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
