### PR TITLE
Fix exports for ESM NodeNext TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Closes #28 

After this, here is the result from attw:

<img width="332" alt="image" src="https://github.com/bpmn-io/min-dash/assets/1120429/b30e55fb-e972-4b6e-a9f7-122c7f0a10c7">

I also confirmed that this fixes the local issue I was having.

To fix CJS, you would need a copy of all of the index.d.ts as index.d.cts, which I was not able to to figure out how to do easily with rollup. That said, this PR is a net improvement, and I would argue great support for NodeNext + ESM is better than worrying too much about the NodeNext + CJS case (cjs without nodenext is still fine).

This also switches from bundlesize to bundlemon. I could not `npm i` due to issues with bundlesize, so I switched to bundlemon, which isn't abandoned.