### PR TITLE
Fix types

### DIFF
--- a/lib/array.d.ts
+++ b/lib/array.d.ts
@@ -5,4 +5,4 @@
  *
  * @return
  */
-export function flatten<T extends any[]>(arr: T[]): T;
+export function flatten<T extends any>(arr: T[] | null): T[];

--- a/lib/array.js
+++ b/lib/array.js
@@ -4,7 +4,7 @@
  *
  * @template T
  *
- * @param {T[][]} arr
+ * @param {T[][] | T[] | null} [arr]
  *
  * @return {T[]}
  */

--- a/lib/collection.d.ts
+++ b/lib/collection.d.ts
@@ -11,7 +11,7 @@ export type ArrayCollection<T> = Array<T>;
 export type StringKeyValueCollection<T> = { [key: string]: T };
 export type NumberKeyValueCollection<T> = { [key: number]: T };
 export type KeyValueCollection<T> = StringKeyValueCollection<T> | NumberKeyValueCollection<T>;
-export type Collection<T> = KeyValueCollection<T> | ArrayCollection<T>;
+export type Collection<T> = KeyValueCollection<T> | ArrayCollection<T> | null | undefined;
 
 /**
  * Find element in collection.

--- a/lib/lang.d.ts
+++ b/lib/lang.d.ts
@@ -4,8 +4,8 @@ import {
 
 export function isUndefined(obj: any): obj is null | undefined;
 export function isDefined(obj: any): obj is Exclude<any, null | undefined>;
-export function isNil(obj: any): obj is object;
-export function isArray(obj: any): obj is Array<any>;
+export function isNil(obj: any): value is null | undefined;
+export function isArray(obj: any): obj is Array;
 export function isObject(obj: any): obj is object;
 export function isNumber(obj: any): obj is number;
 export function isFunction(obj: any): obj is Function;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^14.1.0",
         "@types/mocha": "^10.0.1",
+        "@types/sinon": "^17.0.3",
+        "@types/sinon-chai": "^3.2.12",
         "chai": "^4.3.4",
         "cpx": "^1.5.0",
         "eslint": "^8.28.0",
@@ -324,6 +326,12 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
+      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -350,6 +358,31 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
+      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -6115,6 +6148,12 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
+      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -6141,6 +6180,31 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
+      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@types/mocha": "^10.0.1",
+    "@types/sinon": "^17.0.3",
+    "@types/sinon-chai": "^3.2.12",
     "chai": "^4.3.4",
     "cpx": "^1.5.0",
     "eslint": "^8.28.0",

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -9,6 +9,16 @@ describe('array', function() {
 
   describe('flatten', function() {
 
+    it('should handle null values', function() {
+
+      // then
+      expect(flatten(null)).to.eql([]);
+
+      // @ts-ignore-error "missing arg"
+      expect(flatten()).to.eql([]);
+    });
+
+
     it('should flatten, one level deep', function() {
 
       // given

--- a/test/fn.spec.js
+++ b/test/fn.spec.js
@@ -23,6 +23,8 @@ describe('fn', function() {
 
       // given
       let fn = function() {
+
+        // @ts-ignore-error "this"
         return this.foo;
       };
 
@@ -110,6 +112,8 @@ describe('fn', function() {
       let self = {};
 
       let callback = sinon.spy(function() {
+
+        // @ts-ignore-error "this"
         expect(this).to.equal(self);
       });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+
+import {
+  flatten
+} from '../lib/index.js';
+
+
+describe('min-dash', function() {
+
+  it('should work', function() {
+
+    // given
+    const arr = [ [ 'A', 'B', 'C' ], 'B' ];
+
+    // when
+    expect(flatten(arr)).to.eql(arr);
+  });
+
+});

--- a/test/lang.spec.js
+++ b/test/lang.spec.js
@@ -59,6 +59,7 @@ describe('lang', function() {
 
       expect(isDefined(null)).to.be.true;
 
+      // @ts-ignore-error "missing arg"
       expect(isDefined()).to.be.false;
       expect(isDefined(undefined)).to.be.false;
       expect(isDefined(void 0)).to.be.false;
@@ -79,6 +80,7 @@ describe('lang', function() {
 
       expect(isUndefined(null)).to.be.false;
 
+      // @ts-ignore-error "missing arg"
       expect(isUndefined()).to.be.true;
       expect(isUndefined(undefined)).to.be.true;
       expect(isUndefined(void 0)).to.be.true;
@@ -98,6 +100,8 @@ describe('lang', function() {
       expect(isNil({})).to.be.false;
 
       expect(isNil(null)).to.be.true;
+
+      // @ts-ignore-error "missing arg"
       expect(isNil()).to.be.true;
       expect(isNil(undefined)).to.be.true;
       expect(isNil(void 0)).to.be.true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": [
-    "test/*.js"
+    "test/*.js",
+    "test/*.ts"
   ],
   "compilerOptions": {
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "test/*.js"
   ],
   "compilerOptions": {
+    "strict": true,
     "checkJs": true,
+    "noImplicitAny": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "lib": [


### PR DESCRIPTION
This enables `strict` type checking https://github.com/bpmn-io/min-dash/pull/33/commits/667a82b57fd8b21c545bd67915b51daf7d842a36 (likely enabled by some of our consumers) and uncovers a number of issues in the process. These I fixed in https://github.com/bpmn-io/min-dash/pull/33/commits/e13dc9577e4f7ade2cd5c0e61eaca8bbb2a719eb as part of the PR, too :rocket:.

