### PR TITLE
Correct `flatten` type definition

### DIFF
--- a/lib/array.d.ts
+++ b/lib/array.d.ts
@@ -1,3 +1,7 @@
+import { ArrayCollection } from './collection.js';
+
+type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
+
 /**
  * Flatten array, one level deep.
  *
@@ -5,4 +9,4 @@
  *
  * @return
  */
-export function flatten<T extends any>(arr: T[] | null): T[];
+export function flatten<T>(arr: ArrayCollection<T> | null | undefined): Flatten<T>[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "source-map-support": "^0.5.19",
+        "ts-expect": "^1.3.0",
         "typescript": "^5.3.3"
       }
     },
@@ -5613,6 +5614,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/ts-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-expect/-/ts-expect-1.3.0.tgz",
+      "integrity": "sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10232,6 +10240,12 @@
           "dev": true
         }
       }
+    },
+    "ts-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-expect/-/ts-expect-1.3.0.tgz",
+      "integrity": "sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.19",
+    "ts-expect": "^1.3.0",
     "typescript": "^5.3.3"
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,3 +1,5 @@
+import { expectType } from 'ts-expect';
+
 import { expect } from 'chai';
 
 import {
@@ -7,13 +9,29 @@ import {
 
 describe('min-dash', function() {
 
-  it('should work', function() {
+  describe('should work', function() {
 
-    // given
-    const arr = [ [ 'A', 'B', 'C' ], 'B' ];
+    it('flatten', function() {
 
-    // when
-    expect(flatten(arr)).to.eql(arr);
+      // then
+      expectType<string[]>(flatten([ [ 'A', 'B', 'C' ], 'B' ]));
+      expectType<string[]>(flatten([ 'A', 'B', 'C', 'B' ]));
+      expectType<string[]>(flatten([ [ 'A' ], [ 'B' ], [ 'C', 'B'] ]));
+
+      expectType<(string|number|number[])[]>(flatten([
+        [ 'A', 1 ],
+        [ 'B' ],
+        [ 'C', [ 1, 2, 3 ] ],
+        [ 'D' ]
+      ]));
+
+      expectType<unknown[]>(flatten([ null ]));
+      expectType<unknown[]>(flatten(null));
+
+      // when
+      expect(flatten([ [ 'A', 'B', 'C' ], 'B' ])).to.eql([ 'A', 'B', 'C' ]);
+    });
+
   });
 
 });


### PR DESCRIPTION
### Proposed Changes

Previously it would not appropriately infer the return type:

```typescript
expectType<string[]>(flatten([ [ 'A', 'B', 'C' ], 'B' ]));
expectType<string[]>(flatten([ 'A', 'B', 'C', 'B' ]));
expectType<string[]>(flatten([ [ 'A' ], [ 'B' ], [ 'C', 'B'] ]));
```

Now we verify the types using the [ts-expect](https://github.com/TypeStrong/ts-expect) helper.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
